### PR TITLE
Improved Lulesh Caliper annotation

### DIFF
--- a/apps/LULESH/CMakeLists.txt
+++ b/apps/LULESH/CMakeLists.txt
@@ -1,6 +1,10 @@
 cmake_minimum_required(VERSION 3.0)
-
 project(LULESH CXX)
+
+execute_process(COMMAND whoami OUTPUT_VARIABLE FAULT OUTPUT_STRIP_TRAILING_WHITESPACE)
+
+configure_file(lulesh_caliper_annotated.cc.in ${CMAKE_BINARY_DIR}/lulesh_caliper_annotated.cc)
+
 
 option(WITH_MPI    "Build LULESH with MPI"          TRUE)
 option(WITH_OPENMP "Build LULESH with OpenMP"       TRUE)
@@ -19,7 +23,7 @@ if (WITH_MPI)
 else()
   add_definitions("-DUSE_MPI=0")
 endif()
-
+include_directories(${CMAKE_SOURCE_DIR})
 if (WITH_OPENMP)
   find_package(OpenMP REQUIRED)
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${OpenMP_CXX_FLAGS}")
@@ -55,6 +59,7 @@ set(LULESH_SOURCES
   lulesh-init.cc
   lulesh-util.cc
   lulesh-viz.cc
+  ${CMAKE_BINARY_DIR}/lulesh_caliper_annotated.cc
   lulesh.cc)
 
 set(LULESH_EXEC lulesh2.0)

--- a/apps/LULESH/lulesh-util.cc
+++ b/apps/LULESH/lulesh-util.cc
@@ -39,6 +39,7 @@ static void PrintCommandLineOptions(char *execname, int myRank)
       printf(" -c <cost>       : Extra cost of more expensive regions (def: 1)\n");
       printf(" -f <numfiles>   : Number of files to split viz dump into (def: (np+10)/9)\n");
       printf(" -p              : Print out progress\n");
+      printf(" -g              : Produce Spot Caliper file\n");
       printf(" -v              : Output viz file (requires compiling with -DVIZ_MESH\n");
       printf(" -h              : This message\n");
       printf("\n\n");
@@ -117,6 +118,10 @@ void ParseCommandLineOptions(int argc, char *argv[],
          /* -q */
          else if (strcmp(argv[i], "-q") == 0) {
             opts->quiet = 1;
+            i++;
+         }
+         else if (strcmp(argv[i], "-g") == 0) {
+            opts->spot = 1;
             i++;
          }
          else if (strcmp(argv[i], "-b") == 0) {

--- a/apps/LULESH/lulesh-util.cc
+++ b/apps/LULESH/lulesh-util.cc
@@ -6,7 +6,7 @@
 #include <mpi.h>
 #endif
 #include "lulesh.h"
-
+#include "lulesh_caliper_annotated.h"
 /* Helper function for converting strings to ints, with error checking */
 int StrToInt(const char *token, int *retVal)
 {
@@ -219,6 +219,7 @@ void VerifyAndWriteFinalOutput(Real_t elapsed_time,
    printf("\nElapsed time         = %10.2f (s)\n", elapsed_time);
    printf("Grind time (us/z/c)  = %10.8g (per dom)  (%10.8g overall)\n", grindTime1, grindTime2);
    printf("FOM                  = %10.8g (z/s)\n\n", 1000.0/grindTime2); // zones per second
+   setGlobal("FigureOfMerit",1000.0/grindTime2);
 
    return ;
 }

--- a/apps/LULESH/lulesh.cc
+++ b/apps/LULESH/lulesh.cc
@@ -163,6 +163,7 @@ Additional BSD Notice
 #include <caliper/cali.h>
 
 #include "lulesh.h"
+#include "lulesh_caliper_annotated.h"
 
 
 /*********************************/
@@ -2748,7 +2749,7 @@ int main(int argc, char *argv[])
    struct cmdLineOpts opts;
 
    cali_config_preset("CALI_CALIPER_ATTRIBUTE_PROPERTIES", "function=nested:process_scope,loop=nested:process_scope,iteration#lulesh.cycle=process_scope:asvalue");
-
+   record_caliper_metadata();
 #if USE_MPI   
    Domain_member fieldData ;
 

--- a/apps/LULESH/lulesh.cc
+++ b/apps/LULESH/lulesh.cc
@@ -2748,8 +2748,6 @@ int main(int argc, char *argv[])
    Int_t myRank ;
    struct cmdLineOpts opts;
 
-   cali_config_preset("CALI_CALIPER_ATTRIBUTE_PROPERTIES", "function=nested:process_scope,loop=nested:process_scope,iteration#lulesh.cycle=process_scope:asvalue");
-   record_caliper_metadata();
 #if USE_MPI   
    Domain_member fieldData ;
 
@@ -2761,7 +2759,6 @@ int main(int argc, char *argv[])
    myRank = 0;
 #endif   
 
-   CALI_CXX_MARK_FUNCTION;
 
    /* Set defaults that can be overridden by command line opts */
    opts.its = 9999999;
@@ -2773,6 +2770,7 @@ int main(int argc, char *argv[])
    opts.viz = 0;
    opts.balance = 1;
    opts.cost = 1;
+   opts.spot = 0;
 
    ParseCommandLineOptions(argc, argv, myRank, &opts);
 
@@ -2791,6 +2789,18 @@ int main(int argc, char *argv[])
       printf("To write an output file for VisIt, use -v\n");
       printf("See help (-h) for more options\n\n");
    }
+   if(opts.spot){
+     enable_caliper();
+   }
+   cali_config_preset("CALI_CALIPER_ATTRIBUTE_PROPERTIES", "function=nested:process_scope,loop=nested:process_scope,iteration#lulesh.cycle=process_scope:asvalue");
+   setGlobal("Iterations",opts.its);
+   setGlobal("Problem Size",opts.nx);
+   setGlobal("Number of Regions",opts.numReg);
+   setGlobal("Region Balance",opts.balance);
+   setGlobal("Region Cost",opts.cost);
+   record_caliper_metadata();
+   CALI_CXX_MARK_FUNCTION;
+
 
    // Set up the mesh and decompose. Assumes regular cubes for now
    Int_t col, row, plane, side;

--- a/apps/LULESH/lulesh.h
+++ b/apps/LULESH/lulesh.h
@@ -652,7 +652,7 @@ struct cmdLineOpts {
    Int_t numFiles; // -f
    Int_t showProg; // -p
    Int_t quiet; // -q
-   Int_t spot; // -s
+   Int_t spot; // -g
    Int_t viz; // -v 
    Int_t cost; // -c
    Int_t balance; // -b

--- a/apps/LULESH/lulesh.h
+++ b/apps/LULESH/lulesh.h
@@ -652,6 +652,7 @@ struct cmdLineOpts {
    Int_t numFiles; // -f
    Int_t showProg; // -p
    Int_t quiet; // -q
+   Int_t spot; // -s
    Int_t viz; // -v 
    Int_t cost; // -c
    Int_t balance; // -b

--- a/apps/LULESH/lulesh_caliper_annotated.cc.in
+++ b/apps/LULESH/lulesh_caliper_annotated.cc.in
@@ -2,6 +2,8 @@
 #include "lulesh_caliper_annotated.h"
 #include <caliper/cali.h>
 #include <time.h>
+#include <cstdlib>
+#include <algorithm>
 using valueType = const char*;
 valueType compilerName = "@CMAKE_CXX_COMPILER_ID@";
 valueType compilerVersion = "@CMAKE_CXX_COMPILER_VERSION@";
@@ -16,6 +18,19 @@ void record_caliper_metadata(){
   setGlobal("Compiler Version",compilerVersion);
   setGlobal("Code Builder",blameThisPerson);
   setGlobal("Compiler Flags",compilerFlags);
+  std::string hostname = getenv("HOSTNAME");
+  auto firstdigit = std::find_if(std::begin(hostname),std::end(hostname),[=](const char in){
+      return isdigit(in);
+  });
+  std::string cluster;
+  if(firstdigit == hostname.end()){
+    cluster = hostname;
+  }
+  else{
+    cluster = std::string(std::begin(hostname),firstdigit);
+  }
+  setGlobal("Hostname",hostname.c_str());
+  setGlobal("Cluster",cluster.c_str());
   //setGlobal("Run Start Time",asctime(rt));
 }
 

--- a/apps/LULESH/lulesh_caliper_annotated.cc.in
+++ b/apps/LULESH/lulesh_caliper_annotated.cc.in
@@ -36,5 +36,5 @@ void record_caliper_metadata(){
 
 void enable_caliper(){
   cali_config_preset("CALI_SERVICES_ENABLE","event:aggregate:timestamp:recorder");
-  cali_config_preset("CALI_TIMER_RECORD_INCLUSIVE","true");
+  cali_config_preset("CALI_TIMER_INCLUSIVE_DURATION","true");
 }

--- a/apps/LULESH/lulesh_caliper_annotated.cc.in
+++ b/apps/LULESH/lulesh_caliper_annotated.cc.in
@@ -1,0 +1,15 @@
+#include<string>
+#include "lulesh_caliper_annotated.h"
+#include <caliper/cali.h>
+using valueType = const char*;
+valueType compilerName = "@CMAKE_CXX_COMPILER_ID@";
+valueType compilerVersion = "@CMAKE_CXX_COMPILER_VERSION@";
+valueType blameThisPerson = "@FAULT@";
+valueType compilerFlags = "@CMAKE_CXX_FLAGS@";
+void record_caliper_metadata(){
+  setGlobal("Compiler Name",compilerName);
+  setGlobal("Compiler Version",compilerVersion);
+  setGlobal("Code Builder",blameThisPerson);
+  setGlobal("Compiler Flags",compilerFlags);
+}
+

--- a/apps/LULESH/lulesh_caliper_annotated.cc.in
+++ b/apps/LULESH/lulesh_caliper_annotated.cc.in
@@ -1,15 +1,25 @@
 #include<string>
 #include "lulesh_caliper_annotated.h"
 #include <caliper/cali.h>
+#include <time.h>
 using valueType = const char*;
 valueType compilerName = "@CMAKE_CXX_COMPILER_ID@";
 valueType compilerVersion = "@CMAKE_CXX_COMPILER_VERSION@";
 valueType blameThisPerson = "@FAULT@";
 valueType compilerFlags = "@CMAKE_CXX_FLAGS@";
 void record_caliper_metadata(){
+  time_t timer;
+  /** Not recording time, Caliper has issues with ':' in values? */
+  //time(&timer);
+  //struct tm* rt = localtime(&timer);
   setGlobal("Compiler Name",compilerName);
   setGlobal("Compiler Version",compilerVersion);
   setGlobal("Code Builder",blameThisPerson);
   setGlobal("Compiler Flags",compilerFlags);
+  //setGlobal("Run Start Time",asctime(rt));
 }
 
+void enable_caliper(){
+  cali_config_preset("CALI_SERVICES_ENABLE","event:aggregate:timestamp:recorder");
+  cali_config_preset("CALI_TIMER_RECORD_INCLUSIVE","true");
+}

--- a/apps/LULESH/lulesh_caliper_annotated.h
+++ b/apps/LULESH/lulesh_caliper_annotated.h
@@ -1,6 +1,7 @@
 #pragma once
 #include <caliper/Annotation.h>
 void record_caliper_metadata();
+void enable_caliper();
 template<typename T>
 void setGlobal(const char* name, T val){
   cali::Annotation global_annot(name,CALI_ATTR_GLOBAL);

--- a/apps/LULESH/lulesh_caliper_annotated.h
+++ b/apps/LULESH/lulesh_caliper_annotated.h
@@ -1,0 +1,8 @@
+#pragma once
+#include <caliper/Annotation.h>
+void record_caliper_metadata();
+template<typename T>
+void setGlobal(const char* name, T val){
+  cali::Annotation global_annot(name,CALI_ATTR_GLOBAL);
+  global_annot.set(val);
+}


### PR DESCRIPTION
I've made a few changes to Lulesh. It now records as globals

1) Various build characteristics (Compiler family, compiler flags, username of the person who built the code)
2) Command line arguments
3) Figure of Merit
4) Machine name and "Cluster Name" (machine name minus any numbers)

In addition, you enable Caliper using the "-g" option to lulesh2.0 (everything sensible was taken)